### PR TITLE
Fix for CentOS >= 7.1

### DIFF
--- a/views/install.sh.erb
+++ b/views/install.sh.erb
@@ -106,6 +106,9 @@ if test -f "/etc/lsb-release" && grep -q DISTRIB_ID /etc/lsb-release; then
 elif test -f "/etc/debian_version"; then
   platform="debian"
   platform_version=`cat /etc/debian_version`
+elif test -f "/etc/centos-release" && grep -q ' 7\.' /etc/centos-release; then
+  platform="el"
+  platform_version=`sed 's/^.\+ release \([.0-9]\+\).*/\1/' /etc/centos-release`
 elif test -f "/etc/redhat-release"; then
   platform=`sed 's/^\(.\+\) release.*/\1/' /etc/redhat-release | tr '[A-Z]' '[a-z]'`
   platform_version=`sed 's/^.\+ release \([.0-9]\+\).*/\1/' /etc/redhat-release`


### PR DESCRIPTION
The package `centos-release` changed the formatting of `/etc/redhat-release`
Unless reverted, we should use `/etc/centos-release` to derive the platform version, while maintaining backwards compatibility with older versions.

Addresses https://github.com/chef/opscode-omnitruck/issues/85