### PR TITLE
Support installing non-Chef packages on Solaris

### DIFF
--- a/views/install.sh.erb
+++ b/views/install.sh.erb
@@ -457,8 +457,8 @@ install_file() {
       echo "conflict=nocheck" > $tmp_dir/nocheck
       echo "action=nocheck" >> $tmp_dir/nocheck
       echo "mail=" >> $tmp_dir/nocheck
-      pkgrm -a $tmp_dir/nocheck -n chef >/dev/null 2>&1 || true
-      pkgadd -n -d "$2" -a $tmp_dir/nocheck chef
+      pkgrm -a $tmp_dir/nocheck -n $project >/dev/null 2>&1 || true
+      pkgadd -n -d "$2" -a $tmp_dir/nocheck $project
       ;;
     "pkg")
       echo "installing with installer..."


### PR DESCRIPTION
This change will allow us to install AngryChef packages on Solaris nodes.

/cc @chef/ociv @chef/client-engineers 