### PR TITLE
Platform mappings and bug fixes

### DIFF
--- a/platforms.rb
+++ b/platforms.rb
@@ -13,6 +13,9 @@
 # NB: this platform name is deprecated, convert to using "redhat" like ohai
 platform "el" do
   major_only true
+  version_remap do |version|
+    version == "7" ? "6" : version
+  end
 end
 
 platform "debian" do


### PR DESCRIPTION
This will fix the issue of EL 7 picking up old version of chef client

I'm not sure this is the correct fix though. There are projects other than chef client using platforms.rb, and this basically says everyone must use these mappings. So if any project is actually building on EL 7, they're going to be sad (I think).

cc @schisamo @cheeseplus @yzl @lamont-granquist  