### PR TITLE
always yolo

### DIFF
--- a/lib/platform_dsl.rb
+++ b/lib/platform_dsl.rb
@@ -65,9 +65,6 @@ class PlatformDSL
     def major_only
       raise NotImplementedError, "must be implemented by subclass"
     end
-    def yolo
-      raise NotImplementedError, "must be implemented by subclass"
-    end
     def remap
       raise NotImplementedError, "must be implemented by subclass"
     end
@@ -110,8 +107,7 @@ class PlatformDSL
       "version:        #{version}\n" +
       "mapped name:    #{mapped_name}\n" +
       "mapped version: #{mapped_version}\n" +
-      "major_only:     #{major_only}\n" +
-      "yolo:           #{yolo}\n"
+      "major_only:     #{major_only}\n"
     end
   end
 
@@ -133,7 +129,6 @@ class PlatformDSL
     def initialize(name)
       @name = name
       @major_only = false
-      @yolo = false
       @remap = nil
       @version_remap = nil
     end
@@ -173,14 +168,6 @@ class PlatformDSL
       end
       @version_remap
     end
-
-    def yolo(opt = nil)
-      unless opt.nil?
-        raise "yolo must be true or false" unless opt.instance_of?(TrueClass) || opt.instance_of?(FalseClass)
-        @yolo = opt
-      end
-      @yolo
-    end
   end
 
   def initialize
@@ -193,14 +180,12 @@ class PlatformDSL
     major_only = platform_spec.major_only
     remap = platform_spec.remap
     version_remap = platform_spec.version_remap
-    yolo = platform_spec.yolo
     klass.class_eval do
       define_singleton_method :name do name end
       define_method :name do name end
       define_method :major_only do major_only end
       define_method :remap do remap end
       define_method :version_remap do version_remap end
-      define_method :yolo do yolo end
     end
     add_platform_version(klass)
   end

--- a/platforms.rb
+++ b/platforms.rb
@@ -97,30 +97,23 @@ end
 
 # Unsupported Variants
 #
-# These most likely work, everything below this line has yolo on for all versions
-# so that it prints a warning when installing.
-#
 platform "xenserver" do
-  yolo true
   remap "el"
   version_remap 5
 end
 
 platform "coreos" do
-  yolo true
   remap "el"
   version_remap 6
 end
 
 platform "fedora" do
-  yolo true
   remap "el"
   # FIXME: with some old enough version we should return 5
   version_remap 6
 end
 
 platform "linuxmint" do
-  yolo true
   remap "ubuntu"
   version_remap do |version|
     minor_rev = ( version.to_i % 2 == 0 ) ? "10" : "04"
@@ -132,20 +125,17 @@ end
 # Univention Corporate Server is predominantly used in German
 # FIXME: version_remapping to correct debian version ideally needed
 platform "univention" do
-  yolo true
   remap "debian"
   version_remap 6
 end
 
 # this'll magically work if we ever publish ARM debian builds
 platform "raspbian" do
-  yolo true
   remap "debian"
 end
 
 # see #81
 platform "cumulus networks" do
-  yolo true
   remap "debian"
   version_remap 7
 end

--- a/views/install.sh.erb
+++ b/views/install.sh.erb
@@ -580,13 +580,6 @@ if test "x$cached_file_available" != "xtrue"; then
   do_checksum "$download_filename" "$sha256" "$md5" || checksum_mismatch
 fi
 
-if grep yolo "$metadata_filename" >/dev/null; then
-  echo
-  echo "WARNING: Chef-Client has not been regression tested on this O/S Distribution"
-  echo "WARNING: Do not use this configuration for Production Applications.  Use at your own risk."
-  echo
-fi
-
 if test "x$version" = "x"; then
   echo
   echo "WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING"


### PR DESCRIPTION
the most visible change here is that the banner that everyone
ignored will disappear.  since we're going to explicitly support
things like shipping el5 to el7 systems the yolo banner doesn't
make a whole lot of sense any more.

i think this fixes it so the ancient download points will also
yolo now as well.