### PR TITLE
Fix issue where newly published rc's cannot be fetched with full version string

### DIFF
--- a/lib/opscode/version.rb
+++ b/lib/opscode/version.rb
@@ -75,7 +75,13 @@ module Opscode
     # major, minor, patch, and prerelease values.  Build specifiers
     # are not taken into consideration.
     def in_same_prerelease_line?(other)
-      @major == other.major && @minor == other.minor && @patch == other.patch && @prerelease == other.prerelease
+      @major == other.major && @minor == other.minor && @patch == other.patch && prerelease_eql(other)
+    end
+
+    def prerelease_eql(other)
+      my_prerelease = @prerelease.gsub(/-\d*\z/, '') if @prerelease
+      other_prerelease = other.prerelease.gsub(/-\d*\z/, '') if other.prerelease
+      my_prerelease == other_prerelease
     end
 
     def to_s


### PR DESCRIPTION
For examples, the following was not working:
http://localhost:9393/metadata?v=12.4.0.rc.0&prerelease=false&nightlies=false&p=el&pv=6&m=x86_64

The other way to fix https://github.com/chef/opscode-omnitruck/pull/105