### PR TITLE
Revert #105

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,6 @@ gem 'yajl-ruby'
 gem "rest-client"
 gem 'nokogiri'
 gem 'rake'
-gem 'mixlib-versioning', '~> 1.1.0'
 
 group :test do
   gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,6 @@ GEM
     kgio (2.9.3)
     mime-types (1.25.1)
     mini_portile (0.6.2)
-    mixlib-versioning (1.1.0)
     multi_json (1.11.0)
     netrc (0.10.3)
     nokogiri (1.6.6.2)
@@ -88,7 +87,6 @@ PLATFORMS
 DEPENDENCIES
   colorize
   json
-  mixlib-versioning (~> 1.1.0)
   nokogiri
   rack-test
   rake

--- a/lib/opscode/version.rb
+++ b/lib/opscode/version.rb
@@ -75,7 +75,13 @@ module Opscode
     # major, minor, patch, and prerelease values.  Build specifiers
     # are not taken into consideration.
     def in_same_prerelease_line?(other)
-      @major == other.major && @minor == other.minor && @patch == other.patch && @prerelease == other.prerelease
+      @major == other.major && @minor == other.minor && @patch == other.patch && prerelease_eql(other)
+    end
+
+    def prerelease_eql(other)
+      my_prerelease = @prerelease.gsub(/-\d*\z/, '') if @prerelease
+      other_prerelease = other.prerelease.gsub(/-\d*\z/, '') if other.prerelease
+      my_prerelease == other_prerelease
     end
 
     def to_s

--- a/lib/opscode/version.rb
+++ b/lib/opscode/version.rb
@@ -19,101 +19,128 @@
 # limitations under the License.
 #
 
-require 'mixlib/versioning'
+require 'opscode/version/semver'
+require 'opscode/version/opscode_semver'
+require 'opscode/version/rubygems'
+require 'opscode/version/git_describe'
 require 'opscode/version/incomplete'
-require 'forwardable'
 
 module Opscode
   class Version
-    SUPPORTED_FORMATS = Mixlib::Versioning::DEFAULT_FORMATS + [
-      Opscode::Version::Incomplete
-    ]
-    extend Forwardable
 
     include Comparable
 
-    delegate [:major,
-              :minor,
-              :patch,
-              :prerelease,
-              :build,
-              :release?,
-              :prerelease?,
-              :input,
-              :to_semver_string
-    ] => :mixlib_version
+    attr_reader :major, :minor, :patch, :prerelease, :build, :iteration
 
-    attr_reader :iteration
+    def initialize(version)
+      raise Error, "You must override the initializer!"
+    end
 
-    attr_reader :mixlib_version
+    # Is this an official release?
+    def release?
+      @prerelease.nil? && @build.nil?
+    end
 
-    def initialize(version, iteration)
-      @mixlib_version = version
-      @iteration = iteration.to_i
+    # Is this an official pre-release? (i.e., not a nightly build)
+    def prerelease?
+      @prerelease && @build.nil?
     end
 
     # Is this a nightly build of a release?
     def release_nightly?
-      prerelease.nil? && build
+      @prerelease.nil? && @build
     end
 
     # Is this a nightly build of a pre-release?
     def prerelease_nightly?
-      prerelease && build
+      @prerelease && @build
     end
 
     # Is this a nightly build (either of a release or a pre-release)?
     def nightly?
-      !!build
+      !!@build
     end
 
     # Returns +true+ if +other+ and this +Version+ share the same
     # major, minor, and patch values.  Prerelease and build specifiers
     # are not taken into consideration.
     def in_same_release_line?(other)
-      major == other.major &&
+      @major == other.major &&
         # minor and patch always match if one or the other is nil (~>-like behavior)
-        ( minor.nil? || other.minor.nil? || minor == other.minor ) &&
-        ( patch.nil? || other.patch.nil? || patch == other.patch )
+        ( @minor.nil? || other.minor.nil? || @minor == other.minor ) &&
+        ( @patch.nil? || other.patch.nil? || @patch == other.patch )
     end
 
     # Returns +true+ if +other+ and this +Version+ share the same
     # major, minor, patch, and prerelease values.  Build specifiers
     # are not taken into consideration.
     def in_same_prerelease_line?(other)
-      major == other.major && minor == other.minor && patch == other.patch && prerelease == other.prerelease
-    end
-
-    def prerelease_eql(other)
-
+      @major == other.major && @minor == other.minor && @patch == other.patch && @prerelease == other.prerelease
     end
 
     def to_s
-      if iteration.nil?
-        input
-      else
-        "#{input}-#{iteration}"
-      end
+      raise Error, "You must override #to_s"
+    end
+
+    def to_semver_string
+      s = [@major, @minor, @patch].join(".")
+      s += "-#{@prerelease}" if @prerelease
+      s += "+#{@build}" if @build
+      s
     end
 
     def <=>(other)
 
       # First, perform comparisons based on major, minor, and patch
       # versions.  These are always presnt and always non-nil
-      cmp = mixlib_version <=> other.mixlib_version
-      return cmp unless cmp == 0
+      maj = @major <=> other.major
+      return maj unless maj == 0
+
+      min = @minor <=> other.minor
+      return min unless min == 0
+
+      pat = @patch <=> other.patch
+      return pat unless pat == 0
+
+      # Next compare pre-release specifiers.  A pre-release sorts
+      # before a release (e.g. 1.0.0-alpha.1 comes before 1.0.0), so
+      # we need to take nil into account in our comparison.
+      #
+      # If both have pre-release specifiers, we need to compare both
+      # on the basis of each component of the specifiers.
+      if @prerelease && other.prerelease.nil?
+        return -1
+      elsif @prerelease.nil? && other.prerelease
+        return 1
+      elsif @prerelease && other.prerelease
+        pre = compare_dot_components(@prerelease, other.prerelease)
+        return pre unless pre == 0
+      end
+
+      # Build specifiers are compared like pre-release specifiers,
+      # except that builds sort *after* everything else
+      # (e.g. 1.0.0+build.123 comes after 1.0.0, and
+      # 1.0.0-alpha.1+build.123 comes after 1.0.0-alpha.1)
+      if @build.nil? && other.build
+        return -1
+      elsif @build && other.build.nil?
+        return 1
+      elsif @build && other.build
+        build_ver = compare_dot_components(@build, other.build)
+        return build_ver unless build_ver == 0
+      end
 
       # Some older version formats improperly include a package iteration in
       # the version string. This is different than a build specifier and
       # valid release versions may include an iteration. We'll transparently
       # handle this case and compare iterations if it was parsed by the
       # implementation class.
-      if iteration.nil? && other.iteration
+      if @iteration.nil? && other.iteration
         return -1
-      elsif iteration && other.iteration.nil?
+      elsif @iteration && other.iteration.nil?
         return 1
-      elsif iteration && other.iteration
-        return iteration <=> other.iteration
+      elsif @iteration && other.iteration
+        return @iteration <=> other.iteration
       end
 
       # If we get down here, they're both equal
@@ -121,15 +148,92 @@ module Opscode
     end
 
     def eql?(other)
-      mixlib_version.eql?(other) &&
-        iteration == other.iteration
+      @major == other.major &&
+        @minor == other.minor &&
+        @patch == other.patch &&
+        @prerelease == other.prerelease &&
+        @build == other.build
     end
 
     def hash
-      [major, minor, patch, prerelease, build].compact.join(".").hash
+      [@major, @minor, @patch, @prerelease, @build].compact.join(".").hash
     end
 
     ###########################################################################
+
+    private
+
+    # If a String +n+ can be parsed as an Integer do so; otherwise, do
+    # nothing.
+    #
+    # (+nil+ is a valid input.)
+    def maybe_int(n)
+      Integer(n)
+    rescue
+      n
+    end
+
+    # Compares prerelease and build version component strings
+    # according to semver 2.0.0-rc.1 semantics.
+    #
+    # Returns -1, 0, or 1, just like the spaceship operator (+<=>+),
+    # and is used in the implemntation of +<=>+ for this class.
+    #
+    # Prerelease and build specifiers are dot-separated strings.
+    # Numeric components are sorted numerically; otherwise, sorting is
+    # standard ASCII order.  Numerical components have a lower
+    # precedence than string components.
+    #
+    # See http://www.semver.org for more.
+    #
+    # Both +a_item+ and +b_item+ should be Strings; +nil+ is not a
+    # valid input.
+    def compare_dot_components(a_item, b_item)
+      a_components = a_item.split(".")
+      b_components = b_item.split(".")
+
+      max_length = [a_components.length, b_components.length].max
+
+      (0..(max_length-1)).each do |i|
+        # Convert the ith component into a number if possible
+        a = maybe_int(a_components[i])
+        b = maybe_int(b_components[i])
+
+        # Since the components may be of differing lengths, the
+        # shorter one will yield +nil+ at some point as we iterate.
+        if a.nil? && !b.nil?
+          # a_item was shorter
+          return -1
+        elsif !a.nil? && b.nil?
+          # b_item was shorter
+          return 1
+        end
+
+        # Now we need to compare appropriately based on type.
+        #
+        # Numbers have lower precedence than strings; therefore, if
+        # the components are of differnt types (String vs. Integer),
+        # we just return -1 for the numeric one and we're done.
+        #
+        # If both are the same type (Integer vs. Integer, or String
+        # vs. String), we can just use the native comparison.
+        #
+        if a.is_a?(Integer) && b.is_a?(String)
+          # a_item was "smaller"
+          return -1
+        elsif a.is_a?(String) && b.is_a?(Integer)
+          # b_item was "smaller"
+          return 1
+        else
+          comp = a <=> b
+          return comp unless comp == 0
+        end
+      end # each
+
+      # We've compared all components of both strings; if we've gotten
+      # down here, they're totally the same
+      return 0
+    end
 
     ###########################################################################
     # Class Methods
@@ -194,20 +298,6 @@ module Opscode
 
           in_release_line && (allow_all || v.release?)
         end.max
-      end
-    end
-
-    def self.parse(version_str)
-      # Mixlib::Versioning thinks the iterations at the end of
-      # our semvered omnibus package names are prereleases.
-      # This class will take responsibility of managing the iteration.
-      match = version_str.match /(.*)-(\d*)\z/
-      if match.nil?
-        version = Mixlib::Versioning.parse(version_str, SUPPORTED_FORMATS)
-        Opscode::Version.new(version, nil) if version
-      else
-        version = Mixlib::Versioning.parse(match[1], SUPPORTED_FORMATS)
-        Opscode::Version.new(version, match[2]) if version
       end
     end
   end

--- a/lib/opscode/version/git_describe.rb
+++ b/lib/opscode/version/git_describe.rb
@@ -1,0 +1,73 @@
+#--
+# Author:: Tyler Cloke (tyler@opscode.com)
+# Author:: Stephen Delano (stephen@opscode.com)
+# Author:: Seth Chisamore (sethc@opscode.com)
+# Author:: Lamont Granquist (lamont@opscode.com)
+# Copyright:: Copyright (c) 2010-2013 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Opscode
+  class Version
+    class GitDescribe < Version
+
+      # This class is basically to handle the handful of variations we
+      # currently have in Omnitruck that are based on 'git describe'
+      # output.
+      #
+      # SUPPORTED FORMATS:
+      #
+      #    MAJOR.MINOR.PATCH.PRERELEASE-COMMITS_SINCE-gGIT_SHA
+      #    MAJOR.MINOR.PATCH-PRERELEASE-COMMITS_SINCE-gGIT_SHA
+      #    MAJOR.MINOR.PATCH.PRERELEASE-COMMITS_SINCE-gGIT_SHA-ITERATION
+      #    MAJOR.MINOR.PATCH-PRERELEASE-COMMITS_SINCE-gGIT_SHA-ITERATION
+      #
+      # EXAMPLES:
+      #
+      #    10.16.2-49-g21353f0-1
+      #    10.16.2.rc.1-49-g21353f0-1
+      #    11.0.0-alpha-10-g642ffed
+      #    11.0.0-alpha.1-1-gcea071e
+      #
+      OPSCODE_GIT_DESCRIBE_REGEX = /^(\d+)\.(\d+)\.(\d+)(?:-|.)?(.+)?\-(\d+)\-g([a-g0-9]{7})(?:-|.)?(\d+)?$/
+
+      attr_reader :commits_since, :commit_sha, :iteration
+
+      def initialize(version)
+        match = version.match(OPSCODE_GIT_DESCRIBE_REGEX)
+
+        unless match
+          raise ArgumentError, "'#{version}' is not a valid Opscode 'git-describe' version string!"
+        end
+
+        @major, @minor, @patch, @prerelease, @commits_since, @commit_sha, @iteration = match[1..7]
+        @major, @minor, @patch, @commits_since, @iteration = [@major, @minor, @patch, @commits_since, @iteration].map(&:to_i)
+
+        # Our comparison logic is built around SemVer semantics, so
+        # we'll store our internal information in that format
+        @build = "#{@commits_since}.g#{@commit_sha}.#{@iteration}"
+
+
+        # We succeeded, so stash the original input away for later
+        @input = version
+      end
+
+      def to_s
+        @input
+      end
+
+    end
+  end
+end

--- a/lib/opscode/version/opscode_semver.rb
+++ b/lib/opscode/version/opscode_semver.rb
@@ -1,0 +1,61 @@
+#--
+# Author:: Tyler Cloke (tyler@opscode.com)
+# Author:: Stephen Delano (stephen@opscode.com)
+# Author:: Seth Chisamore (sethc@opscode.com)
+# Author:: Lamont Granquist (lamont@opscode.com)
+# Copyright:: Copyright (c) 2010-2013 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Opscode
+  class Version
+    # Defines the format of the semantic version scheme used for Opscode
+    # projects.  They are SemVer-2.0.0-rc.1 compliant, but we further
+    # constrain the allowable strings for prerelease and build
+    # signifiers for our own internal standards.
+    class OpscodeSemVer < SemVer
+
+      # The pattern is: YYYYMMDDHHMMSS.git.COMMITS_SINCE.SHA1
+      OPSCODE_BUILD_REGEX = /^\d{14}\.git\.\d+\.[a-f0-9]{7}$/
+
+      # Allows the following:
+      #
+      # alpha, alpha.1, alpha.2, etc.
+      # beta, beta.1, beta.2, etc.
+      # rc, rc.1, rc.2, etc.
+      #
+      # TODO: Should we allow bare prerelease tags like "alpha", "beta", and "rc", without a number?
+      # TODO: Should we allow "zero tags", like "alpha.0"?
+      OPSCODE_PRERELEASE_REGEX = /^(alpha|beta|rc)(\.\d+)?$/
+
+      def initialize(version)
+        super(version)
+
+        unless @prerelease.nil?
+          unless @prerelease.match(OPSCODE_PRERELEASE_REGEX)
+            raise ArgumentError, "'#{@prerelease}' is not a valid Opscode prerelease signifier"
+          end
+        end
+
+        unless @build.nil?
+          unless @build.match(OPSCODE_BUILD_REGEX)
+            raise ArgumentError, "'#{@build}' is not a valid Opscode build signifier"
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/lib/opscode/version/rubygems.rb
+++ b/lib/opscode/version/rubygems.rb
@@ -21,32 +21,32 @@
 
 module Opscode
   class Version
-    class Incomplete < Version
+    class Rubygems < Version
 
       # SUPPORTED FORMATS:
       #
-      #    MAJOR.MINOR
-      #    MAJOR
+      #    MAJOR.MINOR.PATCH.PRERELEASE
+      #    MAJOR.MINOR.PATCH.PRERELEASE-ITERATION
       #
       # EXAMPLES:
       #
-      #    10.30
-      #    10
+      #    10.1.1
+      #    10.1.1.alpha.1
+      #    10.16.2-1
       #
-      OPSCODE_INCOMPLETE_REGEX = /^(\d+)(?:\.(\d+)|)$/
+      OPSCODE_RUBYGEMS_REGEX = /^(\d+)\.(\d+)\.(\d+)(?:\.((?:alpha|beta|rc|hotfix)\.\d+))?(?:\-(\d+))?$/
 
       def initialize(version)
-        match = version.match(OPSCODE_INCOMPLETE_REGEX)
-        raise ArgumentError, "'#{version}' is not a valid Opscode Incomplete version string!" unless match
+        match = version.match(OPSCODE_RUBYGEMS_REGEX)
+        raise ArgumentError, "'#{version}' is not a valid Opscode Rubygems version string!" unless match
 
         @input = version
 
-        @major, @minor = match[1..2]
-        @major = @major.to_i
-        @minor = @minor.to_i unless @minor.nil?
+        @major, @minor, @patch, @prerelease, @iteration = match[1..5]
+        @major, @minor, @patch = [@major, @minor, @patch].map(&:to_i)
 
-        @prerelease = nil
-        @build = nil
+        # Do not convert @build to an integer; SemVer sorting logic will handle the conversion
+        @prerelease = nil if (@prerelease.nil? || @prerelease.empty?)
       end
 
       def to_s

--- a/lib/opscode/version/semver.rb
+++ b/lib/opscode/version/semver.rb
@@ -21,32 +21,36 @@
 
 module Opscode
   class Version
-    class Incomplete < Version
+    class SemVer < Version
 
+      # Format that implements SemVer 2.0.0-rc.1 (http://semver.org/)
+      #
       # SUPPORTED FORMATS:
       #
-      #    MAJOR.MINOR
-      #    MAJOR
+      #    MAJOR.MINOR.PATCH
+      #    MAJOR.MINOR.PATCH-PRERELEASE
+      #    MAJOR.MINOR.PATCH-PRERELEASE+BUILD
       #
       # EXAMPLES:
       #
-      #    10.30
-      #    10
+      #    11.0.0
+      #    11.0.0-alpha.1
+      #    11.0.0-alpha1+20121218164140
+      #    11.0.0-alpha1+20121218164140.git.207.694b062
       #
-      OPSCODE_INCOMPLETE_REGEX = /^(\d+)(?:\.(\d+)|)$/
+      SEMVER_REGEX = /^(\d+)\.(\d+)\.(\d+)(?:\-([\dA-Za-z\-\.]+))?(?:\+([\dA-Za-z\-\.]+))?$/
 
       def initialize(version)
-        match = version.match(OPSCODE_INCOMPLETE_REGEX)
-        raise ArgumentError, "'#{version}' is not a valid Opscode Incomplete version string!" unless match
+        match = version.match(SEMVER_REGEX)
+        raise ArgumentError, "'#{version}' is not a valid semver version string!" unless match
 
         @input = version
 
-        @major, @minor = match[1..2]
-        @major = @major.to_i
-        @minor = @minor.to_i unless @minor.nil?
+        @major, @minor, @patch, @prerelease, @build = match[1..5]
+        @major, @minor, @patch = [@major, @minor, @patch].map(&:to_i)
 
-        @prerelease = nil
-        @build = nil
+        @prerelease = nil if (@prerelease.nil? || @prerelease.empty?)
+        @build = nil if (@build.nil? || @build.empty?)
       end
 
       def to_s

--- a/spec/opscode/version/git_describe_spec.rb
+++ b/spec/opscode/version/git_describe_spec.rb
@@ -1,0 +1,233 @@
+#--
+# Author:: Tyler Cloke (tyler@opscode.com)
+# Author:: Stephen Delano (stephen@opscode.com)
+# Author:: Seth Chisamore (sethc@opscode.com)
+# Author:: Lamont Granquist (lamont@opscode.com)
+# Copyright:: Copyright (c) 2010-2013 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'opscode/version'
+
+# TODO: Need to test with regex_2 and regex_3 (see the code)
+
+describe Opscode::Version::GitDescribe do
+  context "#initialize" do
+
+    subject{ Opscode::Version::GitDescribe.new(version_string) }
+
+    context "0.10.8-231-g59d6185" do
+      let(:version_string) { "0.10.8-231-g59d6185" }
+      its(:major){ should eq 0 }
+      its(:minor){ should eq 10 }
+      its(:patch){ should eq 8 }
+      its(:prerelease){ should be_nil }
+      its(:build){ should eq "231.g59d6185.0" }
+      its(:commits_since){ should eq 231 }
+      its(:commit_sha){ should eq "59d6185" }
+      its(:iteration){ should eq 0 }
+    end
+
+    context "10.16.2-49-g21353f0-1" do
+      let(:version_string) { "10.16.2-49-g21353f0-1" }
+      its(:major){ should eq 10 }
+      its(:minor){ should eq 16 }
+      its(:patch){ should eq 2 }
+      its(:prerelease){ should be_nil }
+      its(:build){ should eq "49.g21353f0.1" }
+      its(:commits_since){ should eq 49 }
+      its(:commit_sha){ should eq "21353f0" }
+      its(:iteration){ should eq 1 }
+    end
+
+    context "10.16.2.rc.1-49-g21353f0-1" do
+      let(:version_string) { "10.16.2.rc.1-49-g21353f0-1" }
+      its(:major){ should eq 10 }
+      its(:minor){ should eq 16 }
+      its(:patch){ should eq 2 }
+      its(:prerelease){ should eq "rc.1" }
+      its(:build){ should eq "49.g21353f0.1" }
+      its(:commits_since){ should eq 49 }
+      its(:commit_sha){ should eq "21353f0" }
+      its(:iteration){ should eq 1 }
+    end
+
+    context "10.16.2-rc.1-49-g21353f0-1" do
+      let(:version_string) { "10.16.2-rc.1-49-g21353f0-1" }
+      its(:major){ should eq 10 }
+      its(:minor){ should eq 16 }
+      its(:patch){ should eq 2 }
+      its(:prerelease){ should eq "rc.1" }
+      its(:build){ should eq "49.g21353f0.1" }
+      its(:commits_since){ should eq 49 }
+      its(:commit_sha){ should eq "21353f0" }
+      its(:iteration){ should eq 1 }
+    end
+
+    context "10.16.2-alpha-49-g21353f0-1" do
+      let(:version_string) { "10.16.2-alpha-49-g21353f0-1" }
+      its(:major){ should eq 10 }
+      its(:minor){ should eq 16 }
+      its(:patch){ should eq 2 }
+      its(:prerelease){ should eq "alpha" }
+      its(:build){ should eq "49.g21353f0.1" }
+      its(:commits_since){ should eq 49 }
+      its(:commit_sha){ should eq "21353f0" }
+      its(:iteration){ should eq 1 }
+    end
+
+    context "10.16.2-alpha-49-g21353f0" do
+      let(:version_string) { "10.16.2-alpha-49-g21353f0" }
+      its(:major){ should eq 10 }
+      its(:minor){ should eq 16 }
+      its(:patch){ should eq 2 }
+      its(:prerelease){ should eq "alpha" }
+      its(:build){ should eq "49.g21353f0.0" }
+      its(:commits_since){ should eq 49 }
+      its(:commit_sha){ should eq "21353f0" }
+      its(:iteration){ should eq 0 }
+    end
+
+    def self.should_fail_for(version, reason=nil)
+      it "fails for #{version}#{reason ? " (" + reason + ")" : ""}" do
+        expect {Opscode::Version::GitDescribe.new(version)}.to raise_error(ArgumentError, "'#{version}' is not a valid Opscode 'git-describe' version string!")
+      end
+    end
+
+    context "fails for semver-2.0.0-rc.1 versions" do
+      ["1.0.0",
+       "1.0.0-alpha.1",
+       "1.0.0-alpha.1+build.deadbeef",
+       "1.0.0+build.deadbeef"].each do |v|
+        should_fail_for(v)
+      end
+    end
+
+    context "with various flavors of bad git versions" do
+      [["1.0.0-123-gdeadbeef-1", "too many SHA1 characters"],
+       ["1.0.0-123-gdeadbe-1", "too few SHA1 characters"],
+       ["1.0.0-123-gNOTHEX1-1", "illegal SHA1 characters"],
+       ["1.0.0-123-g1234567-alpha", "non-numeric iteration"],
+       ["1.0.0-alpha-poop-g1234567-1", "non-numeric 'commits_since'"],
+       ["1.0.0-g1234567-1", "missing 'commits_since'"],
+       ["1.0.0-123-1", "missing SHA1"],
+      ].each do |pair|
+        version, reason = pair
+        should_fail_for(version, reason)
+      end
+    end
+  end
+
+  context "PARSING AS SEMVER" do
+    it "works for 10.16.2-49-g21353f0-1, but THIS WON'T COMPARE NICELY WITH OTHER PROPER SemVers!" do
+      s = Opscode::Version::SemVer.new("10.16.2-49-g21353f0-1")
+      expect(s.major).to eq 10
+      expect(s.minor).to eq 16
+      expect(s.patch).to eq 2
+      expect(s.prerelease).to eq "49-g21353f0-1"
+      expect(s.build).to be_nil
+    end
+  end
+
+  context "#to_s" do
+    ["10.16.2-49-g21353f0-1"].each do |v|
+      it "reconstructs the initial input of #{v}" do
+        expect(Opscode::Version::GitDescribe.new(v).to_s).to eq(v)
+      end
+    end
+  end
+
+  versions = [
+              "9.0.1-1-gdeadbee-1",
+              "9.1.2-2-g1234567-1",
+              "10.0.0-1-gabcdefg-1",
+              "10.5.7-2-g21353f0-1",
+              "10.20.2-2-gbbbbbbb-1",
+              "10.20.2-3-gaaaaaaa-1",
+              "9.0.1-2-gdeadbe1-1",
+              "9.0.1-2-gdeadbe1-2", # Don't expect to actually see this, but what the hell...
+              "9.0.1-2-gdeadbe2-1", # Don't expect to actually see this, but what the hell...
+              "9.1.1-2-g1234567-1"
+             ]
+  let(:git_describe_versions){versions.map{|v| Opscode::Version::GitDescribe.new(v)}}
+  let(:sorted_versions) do
+    ["9.0.1-1-gdeadbee-1",
+     "9.0.1-2-gdeadbe1-1",
+     "9.0.1-2-gdeadbe1-2",
+     "9.0.1-2-gdeadbe2-1",
+     "9.1.1-2-g1234567-1",
+     "9.1.2-2-g1234567-1",
+     "10.0.0-1-gabcdefg-1",
+     "10.5.7-2-g21353f0-1",
+     "10.20.2-2-gbbbbbbb-1",
+     "10.20.2-3-gaaaaaaa-1"
+    ].map{|v| Opscode::Version::GitDescribe.new(v)}
+  end
+
+  describe "<=>" do
+    it "sorts all properly" do
+      expect(git_describe_versions.sort).to eq sorted_versions
+    end
+
+    it "finds the min" do
+      expect(git_describe_versions.min).to eq Opscode::Version::GitDescribe.new("9.0.1-1-gdeadbee-1")
+    end
+
+    it "finds the max" do
+      expect(git_describe_versions.max).to eq Opscode::Version::GitDescribe.new("10.20.2-3-gaaaaaaa-1")
+    end
+  end
+
+  describe "build qualifiers" do
+
+    context "no GitDescribeVersion can be a proper release" do
+      versions.each do |v|
+        it "#{v} isn't a release" do
+          expect(Opscode::Version::GitDescribe.new(v).release?).to be false
+        end
+      end
+    end
+
+    context "no GitDescribeVersion can be a proper pre-release" do
+      versions.each do |v|
+        it "#{v} isn't a pre-release" do
+          expect(Opscode::Version::GitDescribe.new(v).prerelease?).to be_falsey
+        end
+      end
+    end
+
+    context "every GitDescribeVersion is a nightly release" do
+      versions.each do |v|
+        it "#{v} is a nightly" do
+          expect(Opscode::Version::GitDescribe.new(v).nightly?).to be true
+        end
+      end
+    end
+  end
+
+  describe "translating to a SemVer string" do
+    let(:git_describe_version_string){"10.16.2-49-g21353f0-1"}
+    let(:git_describe){Opscode::Version::GitDescribe.new(git_describe_version_string)}
+
+    it "generates a semver for a release nightly" do
+      string = git_describe.to_semver_string
+      expect(string).to eq "10.16.2+49.g21353f0.1"
+      semver = Opscode::Version::SemVer.new(string)
+      expect(semver.release_nightly?).to be_truthy
+    end
+  end
+
+end
+

--- a/spec/opscode/version/rubygems_spec.rb
+++ b/spec/opscode/version/rubygems_spec.rb
@@ -1,0 +1,66 @@
+#--
+# Author:: Tyler Cloke (tyler@opscode.com)
+# Author:: Stephen Delano (stephen@opscode.com)
+# Author:: Seth Chisamore (sethc@opscode.com)
+# Author:: Lamont Granquist (lamont@opscode.com)
+# Copyright:: Copyright (c) 2010-2013 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'opscode/version'
+
+describe Opscode::Version::Rubygems do
+  context "#initialize" do
+    versions = [
+                ["10.1.1",             [10,1,1, nil, nil]],
+                ["10.1.1.alpha.1",     [10,1,1, "alpha.1", nil]],
+                ["10.1.1.alpha.2",     [10,1,1, "alpha.2", nil]],
+                ["10.1.1.beta.1",      [10,1,1, "beta.1", nil]],
+                ["10.14.4-1",          [10, 14, 4, nil, "1"]],
+                ["10.14.4-2",          [10, 14, 4, nil, "2"]],
+                ["10.16.0-1",          [10, 16, 0, nil, "1"]],
+                ["10.16.0.rc.0-1",     [10, 16, 0, "rc.0", "1"]],
+                ["10.16.0.rc.1-1",     [10, 16, 0, "rc.1", "1"]],
+                ["10.16.2-1",          [10, 16, 2, nil, "1"]]
+               ]
+
+    versions.each do |input|
+      version_string, pieces = input
+      major, minor, patch, prerelease, iteration = pieces
+
+      it "works for #{version_string}" do
+        v = Opscode::Version::Rubygems.new(version_string)
+        expect(v.major).to eq major
+        expect(v.minor).to eq minor
+        expect(v.patch).to eq patch
+        expect(v.prerelease).to eq prerelease
+        expect(v.build).to be_nil
+        expect(v.iteration).to eq iteration
+      end
+    end
+  end
+
+  describe "translating to a SemVer string" do
+    let(:rubygems_version_string){"10.1.1.alpha.2"}
+    let(:rubygems_version){Opscode::Version::Rubygems.new(rubygems_version_string)}
+
+    it "generates a semver for a prerelease" do
+      string = rubygems_version.to_semver_string
+      expect(string).to eq "10.1.1-alpha.2"
+      semver = Opscode::Version::SemVer.new(string)
+      expect(semver.prerelease?).to be true
+    end
+  end
+end

--- a/spec/opscode/version/semver_spec.rb
+++ b/spec/opscode/version/semver_spec.rb
@@ -1,0 +1,201 @@
+#--
+# Author:: Tyler Cloke (tyler@opscode.com)
+# Author:: Stephen Delano (stephen@opscode.com)
+# Author:: Seth Chisamore (sethc@opscode.com)
+# Author:: Lamont Granquist (lamont@opscode.com)
+# Copyright:: Copyright (c) 2010-2013 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'opscode/version'
+
+describe Opscode::Version::SemVer do
+  context "#initialize" do
+    it "works for 1.0.0" do
+      s = Opscode::Version::SemVer.new("1.0.0")
+      expect(s.major).to eq 1
+      expect(s.minor).to eq 0
+      expect(s.patch).to eq 0
+      expect(s.prerelease).to be_nil
+      expect(s.build).to be_nil
+    end
+
+    it "works for 1.0.0-alpha.1" do
+      s = Opscode::Version::SemVer.new("1.0.0-alpha.1")
+      expect(s.major).to eq 1
+      expect(s.minor).to eq 0
+      expect(s.patch).to eq 0
+      expect(s.prerelease).to eq "alpha.1"
+      expect(s.build).to be_nil
+    end
+
+    it "works for 1.0.0-alpha.1+build.deadbeef" do
+      s = Opscode::Version::SemVer.new("1.0.0-alpha.1+build.deadbeef")
+      expect(s.major).to eq 1
+      expect(s.minor).to eq 0
+      expect(s.patch).to eq 0
+      expect(s.prerelease).to eq "alpha.1"
+      expect(s.build).to eq "build.deadbeef"
+    end
+
+    it "works for 1.0.0+build.deadbeef" do
+      s = Opscode::Version::SemVer.new("1.0.0+build.deadbeef")
+      expect(s.major).to eq 1
+      expect(s.minor).to eq 0
+      expect(s.patch).to eq 0
+      expect(s.prerelease).to be_nil
+      expect(s.build).to eq "build.deadbeef"
+    end
+
+    it "rejects bogus input" do
+      v = "One.does.not-simply+implement.SemVer"
+      expect { Opscode::Version::SemVer.new(v) }.to raise_error(ArgumentError, "'#{v}' is not a valid semver version string!")
+    end
+  end
+
+  context "#to_s" do
+    ["1.0.0",
+     "1.0.0-alpha.1",
+     "1.0.0-alpha.1+build.123",
+     "1.0.0+build.456"].each do |v|
+      it "reconstructs the initial input of #{v}" do
+        expect(Opscode::Version::SemVer.new(v).to_s).to eq(v)
+      end
+    end
+  end
+
+  context "SemVer 2.0.0-rc1 Examples" do
+    let(:versions){["1.0.0-beta.2",
+                    "1.0.0-alpha",
+                    "1.0.0-rc.1+build.1",
+                    "1.0.0",
+                    "1.0.0-beta.11",
+                    "1.0.0+0.3.7",
+                    "1.0.0-rc.1",
+                    "1.0.0-alpha.1",
+                    "1.3.7+build.2.b8f12d7",
+                    "1.3.7+build.11.e0f985a",
+                    "1.3.7+build"]}
+    let(:semvers){versions.map{|v| Opscode::Version::SemVer.new(v)}}
+    let(:sorted_semvers) do
+      ["1.0.0-alpha",
+       "1.0.0-alpha.1",
+       "1.0.0-beta.2",
+       "1.0.0-beta.11",
+       "1.0.0-rc.1",
+       "1.0.0-rc.1+build.1",
+       "1.0.0",
+       "1.0.0+0.3.7",
+       "1.3.7+build",
+       "1.3.7+build.2.b8f12d7",
+       "1.3.7+build.11.e0f985a"].map{|v| Opscode::Version::SemVer.new(v)}
+    end
+
+    describe "<=>" do
+      it "sorts all properly" do
+        expect(semvers.sort).to eq sorted_semvers
+      end
+
+      it "finds the min" do
+        expect(semvers.min).to eq Opscode::Version::SemVer.new("1.0.0-alpha")
+      end
+
+      it "finds the max" do
+        expect(semvers.max).to eq Opscode::Version::SemVer.new("1.3.7+build.11.e0f985a")
+      end
+    end
+
+    describe "build qualifiers" do
+      subject{Opscode::Version::SemVer.new(version)}
+
+      context "Release" do
+        let(:version){"1.0.0"}
+        its(:release?){should be true}
+        its(:prerelease?){should be_falsey}
+        its(:release_nightly?){should be_falsey}
+        its(:prerelease_nightly?){should be_falsey}
+        its(:nightly?){should be_falsey}
+      end
+
+      context "Pre-release" do
+        let(:version){"1.0.0-alpha.1"}
+        its(:release?){should be false}
+        its(:prerelease?){should be true}
+        its(:release_nightly?){should be false}
+        its(:prerelease_nightly?){should be_falsey}
+        its(:nightly?){should be false}
+      end
+
+      context "Nightly pre-release build" do
+        let(:version){"1.0.0-alpha.1+build.123"}
+        its(:release?){should be false}
+        its(:prerelease?){should be false}
+        its(:release_nightly?){should be false}
+        its(:prerelease_nightly?){should be_truthy}
+        its(:nightly?){should be true}
+      end
+
+      context "Nightly release build" do
+        let(:version){"1.0.0+build.123"}
+        its(:release?){should be false}
+        its(:prerelease?){should be_falsey}
+        its(:release_nightly?){should be_truthy}
+        its(:prerelease_nightly?){should be_falsey}
+        its(:nightly?){should be true}
+      end
+    end
+
+    describe "Filtering by Build Qualifiers" do
+      context "releases only" do
+        it "works" do
+          expect(semvers.select(&:release?)).to eq [Opscode::Version::SemVer.new("1.0.0")]
+        end
+      end
+
+      context "prereleases only" do
+        it "works" do
+          filtered = semvers.select(&:prerelease?)
+          expect(filtered.sort).to eq(["1.0.0-alpha",
+                                   "1.0.0-alpha.1",
+                                   "1.0.0-beta.2",
+                                   "1.0.0-beta.11",
+                                   "1.0.0-rc.1"
+                                  ].map{|v| Opscode::Version::SemVer.new(v)})
+        end
+      end
+
+      context "release nightlies only" do
+        it "works" do
+          filtered = semvers.select(&:release_nightly?)
+          expect(filtered.sort).to eq(["1.0.0+0.3.7",
+                                   "1.3.7+build",
+                                   "1.3.7+build.2.b8f12d7",
+                                   "1.3.7+build.11.e0f985a"
+                                  ].map{|v| Opscode::Version::SemVer.new(v)})
+        end
+      end
+
+      context "prereleases nightlies only" do
+        it "works" do
+          filtered = semvers.select(&:prerelease_nightly?)
+          expect(filtered).to eq [Opscode::Version::SemVer.new("1.0.0-rc.1+build.1")]
+        end
+      end
+
+    end
+
+  end
+
+end


### PR DESCRIPTION
This reverts #105 and uses #106 instead. #105 switched to mixlib-versioning, while #106 makes a small patch to fix the bug.

#105 on my box drives 50-60 queries per second less than this patch in our most common type of query(download).

I have a patch which I need to apply on top of this that caches the json files instead of reloading them every time. That patch will add 40-50 queries per second the most common query, and about 100 queries per second for metadata. Not quite clear why using mixlib-versioning is so much slower.

These numbers are rough and apply to ruby 2.1, which is about 2x faster than 1.9.3 in my testing. It might be worth upgrading if we have not already.

cc @schisamo @lamont-granquist @sdelano 