### PR TITLE
route for install.ps1

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -55,6 +55,16 @@ class Omnitruck < Sinatra::Base
     }
   end
 
+  get '/install.ps1' do
+    content_type :txt
+    erb :'install.ps1', {
+      :layout => :'install.ps1',
+      :locals => {
+        :download_url => url("#{settings.virtual_path}/metadata")
+      }
+    }
+  end
+  
   error InvalidDownloadPath do
     status 404
     env['sinatra.error']


### PR DESCRIPTION
@jaym This should add the route for /install.ps1 that was missing.